### PR TITLE
Add proper Python slideprinter demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
   - Dependencies:
     - numpy
     - pytest
+    - websockets
   - Usage:
-    1. Install dependencies: `pip install numpy pytest`
+    1. Install dependencies: `pip install numpy pytest websockets`
     2. Run Python tests: `pytest python/tests`
     3. (Optional) Run the Python-driven flipper demo:
        - Start server: `python flipper_server.py`
@@ -77,6 +78,8 @@
 ## 6. Demos & Usage
  1. `npm install`
  2. `npm test` - run all unit tests.
- 3. Open `cable_joints/cable_joints.html` in a browser or any of the `flipper*.html` demos under the root for interactive demos.
- 4. `python flipper_server.py`
- 5. Open `flipper_python.html` for a fully Python-driven version of flipper.html.
+3. Open `cable_joints/cable_joints.html` in a browser or any of the `flipper*.html` demos under the root for interactive demos.
+4. `python flipper_server.py`
+5. Open `flipper_python.html` for a fully Python-driven version of flipper.html.
+6. `python slideprinter_server.py`
+7. Open `slideprinter_python.html` for a Python-based Slideprinter demo.

--- a/slideprinter_python.html
+++ b/slideprinter_python.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Slideprinter (Python Backend)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
+    <style>
+      body { margin:0; background:#222; color:white; font-family:Arial,sans-serif; }
+      canvas { background:#000; display:block; margin:0 auto; }
+      #controls { text-align:center; margin:10px; }
+      button { margin:0 5px; }
+    </style>
+</head>
+<body>
+<div id="controls">
+  <button id="pauseBtn">Start</button>
+  <button id="resetBtn">Reset</button>
+</div>
+<canvas id="simCanvas" width="600" height="400"></canvas>
+<script>
+const canvas = document.getElementById('simCanvas');
+const ctx = canvas.getContext('2d');
+const pauseBtn = document.getElementById('pauseBtn');
+const resetBtn = document.getElementById('resetBtn');
+let ws;
+let isPaused = true;
+let simState = {};
+let cScale = 150;
+
+function setupCanvas(){
+  canvas.width = canvas.clientWidth;
+  canvas.height = canvas.clientHeight;
+  cScale = canvas.height / 1.7;
+}
+
+function toCanvas(x,y){
+  return {x: canvas.width/2 + x*cScale, y: canvas.height - y*cScale};
+}
+
+function render(){
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  if(simState.balls){
+    simState.balls.forEach(b=>{
+      const p = toCanvas(b.x,b.y);
+      ctx.fillStyle = b.mass < 0 ? '#777' : (b.color || '#ccc');
+      ctx.beginPath();
+      ctx.arc(p.x,p.y,b.radius*cScale,0,2*Math.PI);
+      ctx.fill();
+    });
+  }
+  if(simState.cables){
+    ctx.strokeStyle = '#00FFFF';
+    simState.cables.forEach(c=>{
+      c.joints.forEach(j=>{
+        const pA = toCanvas(j.pA[0],j.pA[1]);
+        const pB = toCanvas(j.pB[0],j.pB[1]);
+        ctx.beginPath();
+        ctx.moveTo(pA.x,pA.y);
+        ctx.lineTo(pB.x,pB.y);
+        ctx.stroke();
+      });
+    });
+  }
+}
+
+function connect(){
+  ws = new WebSocket('ws://localhost:8766');
+  ws.onopen = () => {
+    pauseBtn.disabled = false;
+    resetBtn.disabled = false;
+    setupCanvas();
+  };
+  ws.onmessage = e => {
+    simState = JSON.parse(e.data);
+    if(simState.isPaused !== undefined){
+      isPaused = simState.isPaused;
+      pauseBtn.textContent = isPaused ? 'Resume' : 'Pause';
+    }
+    render();
+  };
+  ws.onclose = () => {
+    pauseBtn.disabled = true;
+    resetBtn.disabled = true;
+    setTimeout(connect,1000);
+  };
+}
+
+function step(){
+  if(ws && ws.readyState === WebSocket.OPEN){
+    ws.send(JSON.stringify({action:'step', steps:1}));
+  }
+}
+
+function loop(){
+  if(!isPaused) step();
+  requestAnimationFrame(loop);
+}
+
+pauseBtn.onclick = () => {
+  if(!ws) return;
+  isPaused = !isPaused;
+  pauseBtn.textContent = isPaused ? 'Resume' : 'Pause';
+  ws.send(JSON.stringify({action:'pause', paused:isPaused}));
+};
+
+resetBtn.onclick = () => {
+  if(ws && ws.readyState === WebSocket.OPEN){
+    isPaused = true;
+    pauseBtn.textContent = 'Start';
+    ws.send(JSON.stringify({action:'reset'}));
+  }
+};
+
+connect();
+setupCanvas();
+render();
+requestAnimationFrame(loop);
+</script>
+</body>
+</html>

--- a/slideprinter_server.py
+++ b/slideprinter_server.py
@@ -1,0 +1,228 @@
+import asyncio
+import json
+import numpy as np
+import websockets
+
+from python.ecs import (
+    World, PauseStateComponent, PositionComponent, VelocityComponent,
+    RadiusComponent, MassComponent, OrientationComponent, AngularVelocityComponent,
+    MomentOfInertiaComponent, RenderableComponent, PrevFinalPosComponent,
+    PrevFinalOrientationComponent, BallTagComponent, CableLinkComponent,
+    DistanceConstraintComponent
+)
+from python.cable_joints_components import (
+    CableJointComponent, CablePathComponent, create_cable_path_component
+)
+from python.geometry import tangent_from_point_to_circle
+from python.common_systems import (
+    PrevFinalPosSystem, PrevFinalOrientationSystem, MovementSystem,
+    AngularMovementSystem, XPBDDistanceConstraintSystem,
+    CableAttachmentUpdateSystem, PBDCableConstraintSolver,
+    PBDVelocityUpdateSystem, PBDAngularVelocityUpdateSystem,
+    PBDBallBallCollisions
+)
+
+
+# --- Helper entity creation ---
+
+def create_spool_entity(world, pos, vel, ang_vel, radius, mass, inertia, restitution, color="#a0a0a0"):
+    spool = world.create_entity()
+    world.add_component(spool, BallTagComponent())
+    world.add_component(spool, PositionComponent(np.array([pos[0], pos[1], 0.0])))
+    world.add_component(spool, VelocityComponent(np.array([vel[0], vel[1], 0.0])))
+    world.add_component(spool, RadiusComponent(radius))
+    world.add_component(spool, MassComponent(mass))
+    world.add_component(spool, RenderableComponent("circle", color))
+    world.add_component(spool, OrientationComponent(0.0))
+    world.add_component(spool, AngularVelocityComponent(ang_vel))
+    world.add_component(spool, MomentOfInertiaComponent(inertia))
+    world.add_component(spool, PrevFinalPosComponent(np.array([pos[0], pos[1], 0.0])))
+    world.add_component(spool, PrevFinalOrientationComponent(0.0))
+    world.add_component(spool, CableLinkComponent())
+    return spool
+
+
+def create_anchor_entity(world, pos, radius=0.01, color="#aaaaaa"):
+    anchor = world.create_entity()
+    world.add_component(anchor, BallTagComponent())
+    world.add_component(anchor, PositionComponent(np.array([pos[0], pos[1], 0.0])))
+    world.add_component(anchor, VelocityComponent(np.zeros(3)))
+    world.add_component(anchor, RadiusComponent(radius))
+    world.add_component(anchor, MassComponent(-1.0))
+    world.add_component(anchor, RenderableComponent("circle", color))
+    world.add_component(anchor, CableLinkComponent())
+    return anchor
+
+
+def create_cable_and_joint(world, anchor_e, spool_e, spool_radius, initial_stored, color="orange", stiffness=20000.0):
+    anchor_pos = world.get_component(anchor_e, PositionComponent).pos
+    spool_pos = world.get_component(spool_e, PositionComponent).pos
+
+    joint = world.create_entity()
+    tang = tangent_from_point_to_circle(anchor_pos, spool_pos, spool_radius, True)
+    rest_len = np.linalg.norm(tang['a_attach'] - tang['a_circle'])
+    world.add_component(joint, CableJointComponent(anchor_e, spool_e, rest_len, tang['a_attach'], tang['a_circle']))
+    world.add_component(joint, RenderableComponent('line', color))
+
+    path_e = world.create_entity()
+    path_comp = create_cable_path_component(
+        world,
+        [joint],
+        ['attachment', 'hybrid'],
+        [True, True],
+        stiffness,
+        [0.0, initial_stored]
+    )
+    world.add_component(path_e, path_comp)
+    return joint, path_e
+
+
+def create_distance_constraint(world, eA, eB, compliance=0.0):
+    constraint = world.create_entity()
+    pos_a = world.get_component(eA, PositionComponent).pos
+    pos_b = world.get_component(eB, PositionComponent).pos
+    rest = np.linalg.norm(pos_a - pos_b)
+    world.add_component(constraint, DistanceConstraintComponent(eA, eB, rest, compliance))
+    world.add_component(constraint, RenderableComponent('line', 'purple'))
+    return constraint
+
+
+# --- Scene setup ---
+
+def setup_scene(world: World):
+    world.clear()
+
+    sim_height = 1.7
+    world.set_resource('gravity', np.array([0.0, 0.0, 0.0]))
+    world.set_resource('dt', 1.0 / 200.0)
+    world.set_resource('simWidth', 1.0)
+    world.set_resource('simHeight', sim_height)
+    world.set_resource('pauseState', PauseStateComponent(True))
+    world.set_resource('debugRenderPoints', {})
+    world.set_resource('grabbedBall', None)
+
+    spool_radius = 0.03
+    spool_mass = 0.005
+    spool_inertia = 30 * 0.5 * spool_mass * spool_radius * spool_radius
+    ball_restitution = 0.5
+    anchor_radius = 0.01
+    turns = 5.0
+    initial_stored = turns * spool_radius * np.pi * 2.0
+    cable_stiffness = 20000.0
+    dist = 0.1
+
+    configs = [
+        {
+            'spoolPos': (0.0, -dist),
+            'spoolVel': (1.0, 0.0),
+            'spoolAng': 5.0,
+            'anchorPos': (0.0, -dist - 2.0)
+        },
+        {
+            'spoolPos': (dist*np.cos(np.pi/6), dist*np.sin(np.pi/6)),
+            'spoolVel': (-1.0/np.sqrt(2), 1.0/np.sqrt(2)),
+            'spoolAng': 5.0,
+            'anchorPos': (2.05*np.cos(np.pi/6), 2.05*np.sin(np.pi/6))
+        },
+        {
+            'spoolPos': (dist*np.cos(5*np.pi/6), dist*np.sin(5*np.pi/6)),
+            'spoolVel': (0.0, 0.0),
+            'spoolAng': 5.0,
+            'anchorPos': (2.05*np.cos(5*np.pi/6), 2.05*np.sin(5*np.pi/6))
+        }
+    ]
+
+    spools = []
+    for cfg in configs:
+        s = create_spool_entity(world, cfg['spoolPos'], cfg['spoolVel'], cfg['spoolAng'],
+                                spool_radius, spool_mass, spool_inertia, ball_restitution)
+        a = create_anchor_entity(world, cfg['anchorPos'], anchor_radius)
+        create_cable_and_joint(world, a, s, spool_radius, initial_stored, stiffness=cable_stiffness)
+        spools.append(s)
+
+    create_distance_constraint(world, spools[0], spools[1])
+    create_distance_constraint(world, spools[1], spools[2])
+    create_distance_constraint(world, spools[2], spools[0])
+
+    if not world.systems:
+        world.register_system(PrevFinalPosSystem())
+        world.register_system(PrevFinalOrientationSystem())
+        world.register_system(MovementSystem())
+        world.register_system(AngularMovementSystem())
+        world.register_system(XPBDDistanceConstraintSystem())
+        world.register_system(CableAttachmentUpdateSystem())
+        world.register_system(PBDCableConstraintSolver())
+        world.register_system(PBDVelocityUpdateSystem())
+        world.register_system(PBDAngularVelocityUpdateSystem())
+        world.register_system(PBDBallBallCollisions())
+
+
+# --- Serialization ---
+
+def world_to_json(world: World) -> str:
+    state = {'balls': [], 'cables': [], 'isPaused': True}
+
+    for ball_id in world.query([BallTagComponent, PositionComponent, RadiusComponent]):
+        pos = world.get_component(ball_id, PositionComponent).pos
+        radius = world.get_component(ball_id, RadiusComponent).radius
+        mass = world.get_component(ball_id, MassComponent).mass
+        renderable = world.get_component(ball_id, RenderableComponent)
+        color = renderable.color if renderable else '#888888'
+        state['balls'].append({'x': pos[0], 'y': pos[1], 'radius': radius, 'mass': mass, 'color': color})
+
+    pause_comp = world.get_resource('pauseState')
+    if pause_comp:
+        state['isPaused'] = pause_comp.paused
+
+    # Cables
+    path_entities = world.query([CablePathComponent])
+    for pid in path_entities:
+        path = world.get_component(pid, CablePathComponent)
+        if not path.joint_entities:
+            continue
+        cable_render = {'joints': []}
+        for jid in path.joint_entities:
+            joint = world.get_component(jid, CableJointComponent)
+            cable_render['joints'].append({
+                'pA': joint.attachment_point_a_world.tolist()[:2],
+                'pB': joint.attachment_point_b_world.tolist()[:2],
+                'restLength': joint.rest_length
+            })
+        state['cables'].append(cable_render)
+
+    return json.dumps(state)
+
+
+# --- WebSocket handler ---
+async def handler(websocket):
+    world = World()
+    setup_scene(world)
+
+    await websocket.send(world_to_json(world))
+
+    async for message in websocket:
+        data = json.loads(message)
+        action = data.get('action')
+        pause_state = world.get_resource('pauseState')
+
+        if action == 'step':
+            if not pause_state.paused:
+                steps = data.get('steps', 0)
+                dt = world.get_resource('dt')
+                for _ in range(steps):
+                    world.update(dt)
+        elif action == 'reset':
+            setup_scene(world)
+        elif action == 'pause':
+            pause_state.paused = data['paused']
+
+        await websocket.send(world_to_json(world))
+
+
+async def main():
+    print('Starting Slideprinter server on ws://localhost:8766')
+    async with websockets.serve(handler, 'localhost', 8766):
+        await asyncio.Future()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- reimplement `slideprinter_server.py` using existing ECS modules
- update HTML frontend to draw balls and cables via WebSocket state
- document dependencies and usage in README

## Testing
- `pytest -q` *(fails: 7 failed, 78 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684a8160c2448333b5b9dfe73a381490