### PR TITLE
Fix InputSystem binding in sliding beads demo

### DIFF
--- a/flipper_with_sliding_beads.html
+++ b/flipper_with_sliding_beads.html
@@ -488,7 +488,7 @@ canvas {
              world.registerSystem(new PrevFinalOrientationSystem());
 
              // 2. Handle user input and non-physics state changes
-             const inputSystemInstance = new InputSystem(canvas);
+            const inputSystemInstance = new InputSystem(canvas, world);
              world.registerSystem(inputSystemInstance);
              world.registerSystem(new InputReplaySystem([], inputSystemInstance));
              world.registerSystem(new FlipperMotionSystem());


### PR DESCRIPTION
## Summary
- bind `world` when creating `InputSystem` in the sliding beads demo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8d9deee48333853a681cf83824b3