### PR TITLE
Add rule about integration test expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,6 @@
 - The Python port lives in `flipper_python.html`, `flipper_server.py`, and the modules under `python/`.
 - When working on one implementation, cross reference the corresponding files from the other implementation to understand how features translate between JS and Python.
 
+## Tests
+- Don't change integration test expectations unless explicitly asked to do so.
+


### PR DESCRIPTION
## Summary
- update AGENTS guidelines

## Testing
- `npm test`
- `pytest` *(fails: Test failed: Balls settled below flippers, but score is 12 (expected 11))*

------
https://chatgpt.com/codex/tasks/task_e_684a916e01388333a12e882d44d198d4