### PR TITLE
Add generic USD parsing and sample scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@
 5. Open `flipper_python.html` for a fully Python-driven version of flipper.html.
 6. `python slideprinter_server.py`
 7. Open `slideprinter_python.html` for a Python-based Slideprinter demo.
+8. `python slideprinter_usd_demo.py` demonstrates loading a USD scene via Warp.
+   Edit the script to parse either `slideprinter/slideprinter.usda` or the
+   provided `flipper_scene.usda` to experiment with different setups.

--- a/flipper_scene.usda
+++ b/flipper_scene.usda
@@ -1,0 +1,87 @@
+#usda 1.0
+(
+    doc = "USD scene for Flipper cable demo"
+)
+
+def Xform "FlipperScene" {
+    def Xform "Ball1" (
+        customData = { string purpose = "ball" }
+    )
+    {
+        double3 xformOp:translate = (0.90, 0.95, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.03
+        double mass = 0.002827433388
+    }
+
+    def Xform "Ball2" (
+        customData = { string purpose = "ball" }
+    )
+    {
+        double3 xformOp:translate = (0.08, 0.5, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.03
+        double mass = 0.002827433388
+    }
+
+    def Xform "Obs3" (
+        customData = { string purpose = "obstacle" }
+    )
+    {
+        double3 xformOp:translate = (0.7, 1.0, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.12
+    }
+
+    def Xform "Obs4" (
+        customData = { string purpose = "obstacle" }
+    )
+    {
+        double3 xformOp:translate = (0.2, 1.2, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.1
+    }
+
+    def Xform "Joint1" (
+        customData = { string purpose = "cable_joint" }
+    )
+    {
+        token entityA = "Ball2"
+        token entityB = "Obs4"
+        double restLength = 0.67313583325
+        double3 attachA = (0.08085505, 0.52998781, 0.0)
+        double3 attachB = (0.10004063, 1.20285018, 0.0)
+    }
+
+    def Xform "Joint2" (
+        customData = { string purpose = "cable_joint" }
+    )
+    {
+        token entityA = "Obs4"
+        token entityB = "Obs3"
+        double restLength = 0.53814496188
+        double3 attachA = (0.23366517, 1.29416292, 0.0)
+        double3 attachB = (0.7403982, 1.11299551, 0.0)
+    }
+
+    def Xform "Joint3" (
+        customData = { string purpose = "cable_joint" }
+    )
+    {
+        token entityA = "Obs3"
+        token entityB = "Ball1"
+        double restLength = 0.13763054614
+        double3 attachA = (0.79143019, 1.07772078, 0.0)
+        double3 attachB = (0.88056981, 0.97285755, 0.0)
+    }
+
+    def Xform "CablePath" (
+        customData = { string purpose = "cable_path" }
+    )
+    {
+        token[] joints = ["Joint1", "Joint2", "Joint3"]
+        token[] linkTypes = ["hybrid-attachment", "rolling", "rolling", "hybrid-attachment"]
+        bool[] cw = [true, true, true, true]
+        double[] stored = [0.0, 0.18856494488, 0.06274932329, 0.0]
+    }
+}

--- a/python/tests/test_usd_parse.py
+++ b/python/tests/test_usd_parse.py
@@ -1,0 +1,20 @@
+import numpy as np
+from slideprinter_usd_demo import parse_slideprinter
+
+
+def test_parse_slideprinter_basic():
+    model, entities, joints, paths, _ = parse_slideprinter('slideprinter/slideprinter.usda')
+    spools = [e for e in entities.values() if e['type'] == 'spool']
+    anchors = [e for e in entities.values() if e['type'] == 'anchor']
+    assert len(spools) == 3
+    assert len(anchors) == 3
+    assert model is None or model.body_count >= 0
+
+
+def test_parse_flipper_scene_joints_and_paths():
+    model, entities, joints, paths, _ = parse_slideprinter('flipper_scene.usda')
+    names = set(entities.keys())
+    assert {'Ball1', 'Ball2', 'Obs3', 'Obs4'}.issubset(names)
+    assert len(joints) == 3
+    assert len(paths) == 1
+    assert paths[0]['linkTypes'][0] == 'hybrid-attachment'

--- a/slideprinter/slideprinter.usda
+++ b/slideprinter/slideprinter.usda
@@ -1,0 +1,84 @@
+#usda 1.0
+(
+    doc = "USD scene for Slideprinter"
+)
+
+def Xform "Slideprinter" {
+    def Xform "SpoolA" (
+        customData = {
+            string purpose = "spool"
+        }
+    )
+    {
+        double3 xformOp:translate = (0.0, -0.1, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.03
+        double mass = 0.005
+        double angVel = 5.0
+        double velX = 1.0
+        double velY = 0.0
+    }
+
+    def Xform "AnchorA" (
+        customData = {
+            string purpose = "anchor"
+        }
+    )
+    {
+        double3 xformOp:translate = (0.0, -2.1, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.01
+    }
+
+    def Xform "SpoolB" (
+        customData = {
+            string purpose = "spool"
+        }
+    )
+    {
+        double3 xformOp:translate = (0.08660254, 0.05, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.03
+        double mass = 0.005
+        double angVel = 5.0
+        double velX = -0.7071
+        double velY = 0.7071
+    }
+
+    def Xform "AnchorB" (
+        customData = {
+            string purpose = "anchor"
+        }
+    )
+    {
+        double3 xformOp:translate = (1.776, 1.025, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.01
+    }
+
+    def Xform "SpoolC" (
+        customData = {
+            string purpose = "spool"
+        }
+    )
+    {
+        double3 xformOp:translate = (-0.08660254, 0.05, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.03
+        double mass = 0.005
+        double angVel = 5.0
+        double velX = 0.0
+        double velY = 0.0
+    }
+
+    def Xform "AnchorC" (
+        customData = {
+            string purpose = "anchor"
+        }
+    )
+    {
+        double3 xformOp:translate = (-1.776, 1.025, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+        double radius = 0.01
+    }
+}

--- a/slideprinter_usd_demo.py
+++ b/slideprinter_usd_demo.py
@@ -1,0 +1,96 @@
+from pxr import Usd, UsdGeom
+import warp.sim
+
+
+def parse_slideprinter(path):
+    """Parse a USD scene describing Slideprinter-style mechanics.
+
+    The function now recognizes generic entities, cable joints and cable paths
+    using ``customData.purpose`` metadata. It returns a Warp model along with
+    dictionaries describing the parsed scene.
+    """
+
+    stage = Usd.Stage.Open(path)
+    builder = warp.sim.ModelBuilder()
+    try:
+        data = warp.sim.parse_usd(stage, builder)
+        model = builder.finalize()
+    except Exception:
+        # USD scene may not contain primitives recognized by Warp. In that case
+        # still allow parsing of custom metadata.
+        data = None
+        model = None
+
+    entities = {}
+    joints = []
+    paths = []
+
+    for prim in stage.Traverse():
+        purpose = prim.GetCustomData().get("purpose") if prim.HasCustomData() else None
+        if not purpose:
+            continue
+
+        name = prim.GetName()
+        xform = UsdGeom.Xformable(prim)
+        pos = [0.0, 0.0]
+        for op in xform.GetOrderedXformOps():
+            if op.GetOpName() == "xformOp:translate":
+                v = op.Get()
+                pos = [float(v[0]), float(v[1])]
+
+        if purpose in {"spool", "anchor", "ball", "obstacle", "flipper"}:
+            info = {"name": name, "type": purpose, "pos": pos}
+            for attr in ["radius", "mass", "angVel", "velX", "velY"]:
+                usd_attr = prim.GetAttribute(attr)
+                if usd_attr:
+                    val = usd_attr.Get()
+                    if val is not None:
+                        info[attr] = val
+            entities[name] = info
+
+        elif purpose == "cable_joint":
+            joint = {
+                "name": name,
+                "entityA": prim.GetAttribute("entityA").Get(),
+                "entityB": prim.GetAttribute("entityB").Get(),
+                "restLength": prim.GetAttribute("restLength").Get(),
+                "attachA": list(prim.GetAttribute("attachA").Get()),
+                "attachB": list(prim.GetAttribute("attachB").Get()),
+            }
+            joints.append(joint)
+
+        elif purpose == "cable_path":
+            path = {
+                "name": name,
+                "joints": list(prim.GetAttribute("joints").Get() or []),
+                "linkTypes": list(prim.GetAttribute("linkTypes").Get() or []),
+                "cw": list(prim.GetAttribute("cw").Get() or []),
+                "stored": list(prim.GetAttribute("stored").Get() or []),
+            }
+            paths.append(path)
+
+    return model, entities, joints, paths, data
+
+
+def run_sim(model, steps=10, dt=1.0/200.0):
+    """Run a tiny Warp simulation just to show the USD data works."""
+    integrator = warp.sim.SemiImplicitIntegrator(model)
+    state = model.state()
+    for _ in range(steps):
+        integrator.step(dt, state)
+    return state
+
+
+def main():
+    model, entities, joints, paths, _ = parse_slideprinter('slideprinter/slideprinter.usda')
+    print(f"Loaded model with {model.body_count} bodies")
+    print('Entities:', list(entities.keys()))
+    print('Joints:', [j['name'] for j in joints])
+    print('Paths:', [p['name'] for p in paths])
+    state = run_sim(model)
+    if model.body_count:
+        print('First body position after sim:', state.body_q[0])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `flipper_scene.usda` with balls, obstacles, joints and a cable path
- improve `parse_slideprinter()` to parse generic entities, cable joints and paths
- update USD demo output messages
- mention the extra USD scene in README
- add tests covering the new parser

## Testing
- `pytest -q` *(fails: test_flipper_autonomous_run_and_settle)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8e07e880833383823e460c0f80a3