### PR TITLE
Add Warp integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@
   - Usage:
     1. Install dependencies: `pip install numpy pytest websockets`
     2. Run Python tests: `pytest python/tests`
-    3. (Optional) Run the Python-driven flipper demo:
-       - Start server: `python flipper_server.py`
-       - Open `flipper_python.html` in a browser.
+    3. Run the Warp solver integration test: `pytest python/tests/test_flipper_warp_integration.py`
+    4. (Optional) Run the Python-driven flipper demo:
+      - Start server: `python flipper_server.py`
+      - Open `flipper_python.html` in a browser.
 
   ## 4. Core Library (`cable_joints_core.js`)
  ### a. Geometry Utilities

--- a/python/tests/test_flipper_warp_integration.py
+++ b/python/tests/test_flipper_warp_integration.py
@@ -1,0 +1,81 @@
+import pytest
+import numpy as np
+
+from python.ecs import World, PositionComponent, BallTagComponent
+from flipper_server_warp import setup_scene, ScoreComponent
+
+
+def get_game_state_for_test(world):
+    """Helper function to extract ball positions and score from the world."""
+    state = {'balls': [], 'score': 0}
+
+    ball_entities = world.query([BallTagComponent, PositionComponent])
+    for ball_id in ball_entities:
+        pos_comp = world.get_component(ball_id, PositionComponent)
+        state['balls'].append({'id': ball_id, 'y': pos_comp.pos[1]})
+
+    score_query = world.query([ScoreComponent])
+    if score_query:
+        score_comp = world.get_component(score_query[0], ScoreComponent)
+        state['score'] = score_comp.value
+
+    return state
+
+
+def test_flipper_warp_autonomous_run_and_settle():
+    world = World()
+    setup_scene(world)
+
+    pause_state = world.get_resource('pauseState')
+    pause_state.paused = False
+
+    EXPECTED_SCORE = 11  # Expect same score as non-warp solver
+    MAX_SIMULATION_STEPS = 100 * 300
+    POLLING_INTERVAL_STEPS = 300
+    FLIPPER_Y_LINE = 0.05
+    SCORE_GUARDRAIL = 83
+
+    dt = world.get_resource('dt')
+
+    test_passed = False
+    settled = False
+
+    for step in range(MAX_SIMULATION_STEPS):
+        world.update(dt)
+        if step > 0 and step % POLLING_INTERVAL_STEPS == 0:
+            game_state = get_game_state_for_test(world)
+            balls = game_state['balls']
+            score = game_state['score']
+
+            if score > SCORE_GUARDRAIL:
+                pytest.fail(f"Test failed: Score exceeded {SCORE_GUARDRAIL}. Current score: {score}")
+
+            all_balls_below_flippers = len(balls) > 0
+            if not balls:
+                all_balls_below_flippers = False
+            else:
+                for ball in balls:
+                    if ball['y'] >= FLIPPER_Y_LINE:
+                        all_balls_below_flippers = False
+                        break
+
+            if all_balls_below_flippers:
+                print(f"All balls detected below flipper line (Y < {FLIPPER_Y_LINE}) at step {step}. Current score: {score}.")
+                settled = True
+                if score == EXPECTED_SCORE:
+                    test_passed = True
+                else:
+                    pytest.fail(f"Test failed: Balls settled below flippers, but score is {score} (expected {EXPECTED_SCORE}).")
+                break
+
+    if not settled:
+        final_game_state = get_game_state_for_test(world)
+        pytest.fail(
+            f"Test failed: Timeout. Balls did not settle below flippers within {int(MAX_SIMULATION_STEPS / POLLING_INTERVAL_STEPS)}s. Final score: {final_game_state['score']}"
+        )
+
+    assert settled, "Balls should have settled"
+    assert test_passed, "Test condition for score was not met."
+
+    final_score = get_game_state_for_test(world)['score']
+    assert final_score == EXPECTED_SCORE, f"Final score should be {EXPECTED_SCORE}"


### PR DESCRIPTION
## Summary
- test flipper_server_warp similarly to existing integration
- document how to run the warp solver integration test in README

## Testing
- `pytest -q python/tests/test_flipper_integration.py python/tests/test_flipper_warp_integration.py -vvv` *(fails: Balls settled below flippers, but score mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_684c5b6901608333a33ad6c364599aab