### PR TITLE
Extend 3d vector math

### DIFF
--- a/cable_joints_3d/vector3.js
+++ b/cable_joints_3d/vector3.js
@@ -17,5 +17,31 @@ export default class Vector3 {
     this.z * v.x - this.x * v.z,
     this.x * v.y - this.y * v.x
   ); }
+  crossVectors(a, b) {
+    this.x = a.y * b.z - a.z * b.y;
+    this.y = a.z * b.x - a.x * b.z;
+    this.z = a.x * b.y - a.y * b.x;
+    return this;
+  }
+  angleTo(v) {
+    const dot = this.dot(v);
+    const lenProd = this.length() * v.length();
+    if (lenProd === 0) return 0.0;
+    return Math.acos(Math.max(-1.0, Math.min(1.0, dot / lenProd)));
+  }
+  rotateAroundAxis(axis, angle) {
+    const n = axis.clone().normalize();
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const dot = this.dot(n);
+    const cross = n.cross(this);
+    const term1 = this.clone().scale(cos);
+    const term2 = cross.scale(sin);
+    const term3 = n.clone().scale(dot * (1 - cos));
+    this.x = term1.x + term2.x + term3.x;
+    this.y = term1.y + term2.y + term3.y;
+    this.z = term1.z + term2.z + term3.z;
+    return this;
+  }
   normalize() { const l = this.length(); if (l>0) this.scale(1/l); return this; }
 }

--- a/tests/vector3.test.js
+++ b/tests/vector3.test.js
@@ -6,3 +6,19 @@ test('length and distance work in 3D', () => {
   expect(a.length()).toBeCloseTo(Math.sqrt(14));
   expect(a.distanceTo(b)).toBeCloseTo(5);
 });
+
+test('angleTo returns expected values', () => {
+  const v1 = new Vector3(1,0,0);
+  const v2 = new Vector3(0,1,0);
+  expect(v1.angleTo(v2)).toBeCloseTo(Math.PI/2);
+  expect(v1.angleTo(v1.clone())).toBeCloseTo(0);
+});
+
+test('rotateAroundAxis rotates vector correctly', () => {
+  const v = new Vector3(1,0,0);
+  const axis = new Vector3(0,0,1);
+  v.rotateAroundAxis(axis, Math.PI/2);
+  expect(v.x).toBeCloseTo(0);
+  expect(v.y).toBeCloseTo(1);
+  expect(v.z).toBeCloseTo(0);
+});


### PR DESCRIPTION
## Summary
- add rotation helpers to `Vector3`
- expand vector3 tests for new methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de76d1b6083339efba7a6816ee2e2