### PR TITLE
Improve reset functionality in flipper runner

### DIFF
--- a/cable_joints/commonSystems.js
+++ b/cable_joints/commonSystems.js
@@ -407,6 +407,12 @@ export class InputReplaySystem {
       }
     }
   }
+
+  reset() {
+    this.inputLog = [];
+    this.currentIndex = 0;
+    this.frame = 0;
+  }
 }
 
 export class PBDBallFlipperCollisions {
@@ -576,6 +582,14 @@ export class InputSystem {
     this.canvas.addEventListener('pointermove', this.handlePointerMove.bind(this));
     this.canvas.addEventListener('keydown', this.handleKeydown.bind(this));
     this.canvas.addEventListener('keyup', this.handleKeyup.bind(this));
+  }
+
+  reset() {
+    this.clicks = [];
+    this.releases = [];
+    this.eventLog = [];
+    this.frame = 0;
+    this.grabSpring = null;
   }
 
   // on Space → emit minimal debug dump

--- a/flipper_runner.js
+++ b/flipper_runner.js
@@ -1,6 +1,9 @@
 import { dumpWorldState } from './cable_joints/debugUtils.js';
+import { InputSystem, InputReplaySystem } from './cable_joints/commonSystems.js';
 
 export function runGame(world, setupScene, sceneData) {
+    const originalScene = sceneData ? (typeof structuredClone === 'function' ?
+        structuredClone(sceneData) : JSON.parse(JSON.stringify(sceneData))) : null;
     const pauseBtn = document.getElementById("pauseBtn");
     const resetBtn = document.getElementById("resetBtn");
     const stepBtn = document.getElementById("stepBtn");
@@ -58,7 +61,17 @@ export function runGame(world, setupScene, sceneData) {
 
     resetBtn.addEventListener('click', (e) => {
         e.preventDefault();
-        setupScene(sceneData);
+        const data = originalScene ? (typeof structuredClone === 'function' ?
+            structuredClone(originalScene) : JSON.parse(JSON.stringify(originalScene))) : sceneData;
+        setupScene(data);
+        // reset any input related state
+        for (const sys of world.systems) {
+            if (sys instanceof InputSystem || sys instanceof InputReplaySystem) {
+                if (typeof sys.reset === 'function') sys.reset();
+            }
+        }
+        lastTime = 0;
+        accumulator = 0;
         const pauseState = world.getResource('pauseState');
         if (pauseState) pauseState.paused = true;
         pauseBtn.textContent = "Start";


### PR DESCRIPTION
## Summary
- add `reset()` helpers to `InputSystem` and `InputReplaySystem`
- keep a pristine copy of the scene data in `runGame`
- restore the initial scene and reset input systems on Reset button press

## Testing
- `npm test` *(fails: Flipper Integration Test expected score 12 but got 11)*

------
https://chatgpt.com/codex/tasks/task_e_6850090c39a48333bd56c105aa48c651