### PR TITLE
Update CI workflow to ignore deploy_flipper

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,9 @@
 name: Node.js CI
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - deploy_flipper
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- ensure Node.js CI doesn't run when deploying flipper

## Testing
- `npm test`
- `python -m pytest` *(fails: Test failed: Balls settled below flippers, but score is 36 (expected 28))*

------
https://chatgpt.com/codex/tasks/task_e_6859168f34388333bcd459405f2e10a8