### PR TITLE
Adjust friction iteration scaling

### DIFF
--- a/src/python/cable_joints/cable_friction_system.py
+++ b/src/python/cable_joints/cable_friction_system.py
@@ -7,6 +7,16 @@ from .ecs import (
 from .cable_joints_components import CablePathComponent, CableJointComponent
 from .vector2 import normalize_inplace
 
+# Base iteration count tuned for a 60 Hz frame time.  When the simulation uses
+# smaller timesteps, we reduce the per‑step iterations so that the total number
+# of friction iterations per real‑time second stays roughly constant.  See
+# `ai_docs/CableJoints/CableJoints.md` for the friction model and
+# `ai_docs/Smallsteps/Smallsteps.md` for why the work should scale with the
+# timestep size.
+
+BASE_ITERATIONS = 4
+TARGET_DT = 1.0 / 60.0
+
 def _even_out_tension_friction(world):
     path_entities = world.query([CablePathComponent])
     epsilon = 1e-9
@@ -127,8 +137,10 @@ class CableFrictionSystem:
         self.run_in_pause = False
 
     def update(self, world, dt):
-        # Iterate a few times to allow tension to propagate along the entire cable path.
-        for _ in range(4):
+        # Keep the total number of friction iterations per real-time second
+        # constant as described in Smallsteps.md.
+        iterations = max(1, int(BASE_ITERATIONS * dt / TARGET_DT))
+        for _ in range(iterations):
             _even_out_tension_friction(world)
         
         _sanity_check(world)

--- a/src/python/cable_joints/cable_slack_system.py
+++ b/src/python/cable_joints/cable_slack_system.py
@@ -2,6 +2,14 @@ import numpy as np
 
 from .cable_joints_components import CablePathComponent, CableJointComponent
 
+# Adjust the number of slack iterations so the cost per second remains
+# constant regardless of substep size.  See `ai_docs/CableJoints/CableJoints.md`
+# and `ai_docs/Smallsteps/Smallsteps.md` for details on the model and the
+# rationale behind scaling work with the timestep.
+
+BASE_ITERATIONS = 4
+TARGET_DT = 1.0 / 60.0
+
 def _slip_slack(world):
     path_entities = world.query([CablePathComponent])
     for path_id in path_entities:
@@ -43,6 +51,8 @@ class CableSlackSystem:
         self.run_in_pause = False
 
     def update(self, world, dt):
-        # Iterate a few times to allow slack to propagate along the entire cable path.
-        for _ in range(4):
+        # Scale iterations with dt so slack propagation work per second
+        # matches the target budget (see Smallsteps.md).
+        iterations = max(1, int(BASE_ITERATIONS * dt / TARGET_DT))
+        for _ in range(iterations):
             _slip_slack(world)

--- a/src/python/cable_joints/cable_slip_slack_friction_system.py
+++ b/src/python/cable_joints/cable_slip_slack_friction_system.py
@@ -7,6 +7,14 @@ from .ecs import (
 from .cable_joints_components import CablePathComponent, CableJointComponent
 from .vector2 import normalize_inplace
 
+# Similar to CableFrictionSystem we want a fixed amount of work per second.
+# These constants reference `ai_docs/CableJoints/CableJoints.md` for the
+# friction model and `ai_docs/Smallsteps/Smallsteps.md` for maintaining a
+# constant compute budget as the timestep changes.
+
+BASE_ITERATIONS = 4
+TARGET_DT = 1.0 / 60.0
+
 def _slip_slack(world):
     path_entities = world.query([CablePathComponent])
     for path_id in path_entities:
@@ -159,9 +167,10 @@ class CableSlipSlackFrictionSystem:
         self.run_in_pause = False
 
     def update(self, world, dt):
-        # Iterate a few times to allow slack and tension to propagate
-        # along the entire cable path.
-        for _ in range(4):
+        # Scale iterations with dt so the overall cost per second stays
+        # approximately constant (see Smallsteps.md).
+        iterations = max(1, int(BASE_ITERATIONS * dt / TARGET_DT))
+        for _ in range(iterations):
             _slip_slack(world)
             _even_out_tension_friction(world)
         


### PR DESCRIPTION
## Summary
- reduce CableFrictionSystem iteration count when dt is small
- do the same for CableSlipSlackFrictionSystem and CableSlackSystem
- note reference docs in comments

## Testing
- `python -m pytest tests/python` *(fails: AssertionError: Final score should be 8)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a84f332cc833395250ca5ba308c77