### PR TITLE
Update docs for standalone slideprinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,21 @@ This project simulates cables using a Position‑Based Dynamics (PBD) solver bui
    ```bash
    npx vite
    ```
-2. In another terminal start the slideprinter server:
+2. For a pure JavaScript run open <http://localhost:5173/hp-sim5/slideprinter.html> and use the **Load G-code** button to drive the local MoveCommander worker.
+3. To connect a Python backend start the slideprinter server:
    ```bash
    python -m examples.python.slideprinter.server
    ```
-3. Open <http://localhost:5173/hp-sim5/examples/python/slideprinter/index.html> in your browser.
-4. Issue move commands:
+   and open <http://localhost:5173/hp-sim5/examples/python/slideprinter/index.html>.
+4. Issue move commands from Python (connects via WebSocket):
    ```bash
    python -m examples.python.slideprinter.move_commander examples/python/slideprinter/tighten.gcode
    python -m examples.python.slideprinter.move_commander examples/python/slideprinter/draw_squares.gcode
    ```
+   The `MoveCommander` constructor now accepts optional `anchors_mm`,
+   `spool_radius_mm`, `low_axis_max_force`, `use_flex` and
+   `spool_buildup_factor` parameters for fine‑tuning, mirroring the Python
+   implementation.
 
 ### Running the tests
 JavaScript tests use Jest and Python tests use pytest.

--- a/README_adv.md
+++ b/README_adv.md
@@ -28,12 +28,17 @@ A physics engine for simulating cables, built on a Position-Based Dynamics (PBD)
    - `npx vite`
    - You might have to do `npm install` the first time?
    - Open for example http://localhost:5173/flipper.html in browser. Or:
- - Js based demos are also available at [tobbelobb.github.io/hp-sim5/flipper](https://tobbelobb.github.io/hp-sim5/flipper), [tobbelobb.github.io/hp-sim5/flipper_with_sliding_beads](https://tobbelobb.github.io/hp-sim5/flipper_with_sliding_beads), [tobbelobb.github.io/hp-sim5/flipper_with_attached_beads](https://tobbelobb.github.io/hp-sim5/flipper_with_attached_beads)
- - Slideprinter demo at `examples/python/slideprinter/index.html`. Start `npx vite` and in another terminal run
-   `python -m examples.python.slideprinter.server`. Then you can move it with
-   `python -m examples.python.slideprinter.move_commander`.
-   The move commander and server understand G1, G6 and G92 commands, acting as
-   the firmware for the current Python Slideprinter.
+- Js based demos are also available at [tobbelobb.github.io/hp-sim5/flipper](https://tobbelobb.github.io/hp-sim5/flipper), [tobbelobb.github.io/hp-sim5/flipper_with_sliding_beads](https://tobbelobb.github.io/hp-sim5/flipper_with_sliding_beads), [tobbelobb.github.io/hp-sim5/flipper_with_attached_beads](https://tobbelobb.github.io/hp-sim5/flipper_with_attached_beads)
+- Slideprinter demo at `examples/python/slideprinter/index.html`. Start `npx vite` and in another terminal run
+  `python -m examples.python.slideprinter.server`. Then you can move it with
+  `python -m examples.python.slideprinter.move_commander`.
+  The move commander and server understand G1, G6 and G92 commands, acting as
+  the firmware for the current Python Slideprinter.
+ - To try the JS front end alone, start `npx vite` and open `slideprinter.html`.
+   Upload a G-code file to run the JS `MoveCommander` locally without any WebSocket.
+   The Python `move_commander` can also send commands over WebSocket (`ws://localhost:8768`).
+   `MoveCommander` constructors in both languages now accept optional `anchors_mm`,
+   `spool_radius_mm`, `low_axis_max_force`, `use_flex` and `spool_buildup_factor` arguments.
 
   ## 3. Python Port
   A complete Python port of the cable joints engine is available in the `src/python/cable_joints/` directory, mirroring the JavaScript implementation with equivalent ECS, geometry, and PBD systems.

--- a/examples/js/slideprinter/index.html
+++ b/examples/js/slideprinter/index.html
@@ -1,4 +1,12 @@
 <!DOCTYPE html>
+<!--
+  Start with:  npx vite
+  Open http://localhost:5173/hp-sim5/slideprinter.html
+  Upload a G-code file to run the JS MoveCommander locally.
+  To drive it from Python instead run
+    python -m examples.python.slideprinter.move_commander <file>
+  which connects via WebSocket.
+-->
 <html>
 <head>
     <title>Slideprinter</title>


### PR DESCRIPTION
## Summary
- explain how to start the slideprinter front end by itself
- document connecting the Python move commander over WebSocket
- note optional constructor parameters for MoveCommander
- add quick usage comment to the slideprinter HTML example

## Testing
- `npm test`
- `python -m pytest tests/python` *(fails: AssertionError in flipper integration)*

------
https://chatgpt.com/codex/tasks/task_e_68654d8595f88333913074213e55e13f