### PR TITLE
Sync extrusion events via component

### DIFF
--- a/examples/js/slideprinter/remote_runner.js
+++ b/examples/js/slideprinter/remote_runner.js
@@ -102,12 +102,8 @@ function rebuildWorldFromState(world, state) {
     if (newExtruderEntities.length > 0) {
         const extruderComp = world.getComponent(newExtruderEntities[0], ExtruderComponent);
         if (extruderComp) {
-            extruderComp.extrusions = existingExtrusions;
-            if (state.resources && state.resources.extrusion_events) {
-                for (const event of state.resources.extrusion_events) {
-                    extruderComp.extrusions.push(event);
-                }
-            }
+            const incremental = extruderComp.extrusions || [];
+            extruderComp.extrusions = existingExtrusions.concat(incremental);
         }
     }
 }

--- a/examples/js/slideprinter/setupScene.js
+++ b/examples/js/slideprinter/setupScene.js
@@ -95,7 +95,6 @@ export function setupScene(world, stage, canvas, options = {}) {
     world.setResource('debugRenderPoints', {});
     world.setResource('errorState', new SimulationErrorStateComponent(false));
     world.setResource('grabbedBall', null);
-    world.setResource('extrusion_events', []);
 
     if (!isRemote) {
         // This block remains unchanged, it's for local simulation.

--- a/examples/js/slideprinter/slideprinter_common.js
+++ b/examples/js/slideprinter/slideprinter_common.js
@@ -141,11 +141,8 @@ export class RemoteSpoolSystem {
                 break;
             }
             if (extruderComp != null) {
-                const extrusionEvents = world.getResource("extrusion_events");
-                if (extrusionEvents != null) {
-                    const extrusionEvent = [extruderComp.centerPos.clone(), command.E];
-                    extrusionEvents.push(extrusionEvent);
-                }
+                const extrusionEvent = [extruderComp.centerPos.clone(), command.E];
+                extruderComp.extrusions.push(extrusionEvent);
             }
         }
 

--- a/examples/python/slideprinter/server.py
+++ b/examples/python/slideprinter/server.py
@@ -198,7 +198,7 @@ class RemoteSpoolSystem:
                 break
             if extruder_comp:
                 extrusion_event = (extruder_comp.center_pos.copy(), command['E'])
-                world.get_resource("extrusion_events").append(extrusion_event)
+                extruder_comp.extrusions.append(extrusion_event)
 
         for axis, entity_id in self.axis_to_entity.items():
             if command and command['type'] == 'Move' and axis in command:
@@ -320,7 +320,6 @@ def stage_to_world(world, stage):
     world.set_resource("pauseState", PauseStateComponent(False))
     world.set_resource("debugRenderPoints", {})
     world.set_resource("grabbedBall", None)
-    world.set_resource("extrusion_events", [])
 
     physics_scene = stage.GetPrimAtPath("/World/PhysicsScene")
     if physics_scene:
@@ -559,7 +558,7 @@ def world_to_full_state_json(world: World) -> str:
     for name, resource in world.resources.items():
         if name in ['grabbedBall', 'debugRenderPoints']:
             continue
-        if name in ['dt', 'gravity', 'pauseState', 'extrusion_events']:
+        if name in ['dt', 'gravity', 'pauseState']:
              state['resources'][name] = dataclasses.asdict(resource) if dataclasses.is_dataclass(resource) else resource
 
     return json.dumps(state, cls=NpEncoder)
@@ -568,7 +567,11 @@ def world_to_full_state_json(world: World) -> str:
 # --- WebSocket handler ---
 async def handler(websocket, world, remote_spool_system, grab_spool_system):
     state_json = world_to_full_state_json(world)
-    world.get_resource("extrusion_events").clear()
+    for e in world.query([ExtruderComponent]):
+        extruder_comp = world.get_component(e, ExtruderComponent)
+        if extruder_comp:
+            extruder_comp.extrusions.clear()
+            break
     await websocket.send(state_json)
 
     async for message in websocket:
@@ -598,7 +601,11 @@ async def handler(websocket, world, remote_spool_system, grab_spool_system):
                     grab_spool_system.add_event({'type': event_type, 'pos': pos})
 
         state_json = world_to_full_state_json(world)
-        world.get_resource("extrusion_events").clear()
+        for e in world.query([ExtruderComponent]):
+            extruder_comp = world.get_component(e, ExtruderComponent)
+            if extruder_comp:
+                extruder_comp.extrusions.clear()
+                break
         await websocket.send(state_json)
 
 

--- a/examples/python/slideprinter/slideprinter_common.py
+++ b/examples/python/slideprinter/slideprinter_common.py
@@ -27,6 +27,7 @@ from cable_joints.ecs import (
 class ExtruderComponent:
     """Represents the state of the extruder."""
     center_pos: np.ndarray = field(default_factory=lambda: np.zeros(3))
+    extrusions: list = field(default_factory=list)
 
 
 class ExtruderSystem:


### PR DESCRIPTION
## Summary
- drop the `extrusion_events` resource entirely
- store extrusion events in `ExtruderComponent` for both Python and JS
- send/clear these events from the component in the websocket handler
- merge incremental events on the JS client

## Testing
- `npm test`
- `pytest -q` *(fails: Final score should be 8 / 68)*

------
https://chatgpt.com/codex/tasks/task_e_6866406a93e883339b7cd0ba2adbbf10