### PR TITLE
Fix RenderSystem update frequency

### DIFF
--- a/examples/js/slideprinter/remote_runner.js
+++ b/examples/js/slideprinter/remote_runner.js
@@ -1,5 +1,4 @@
 import { dumpWorldState } from '../../../src/js/cable_joints/debugUtils.js';
-import { RenderSystem } from '../flipper/renderSystem.js';
 import Vector2 from '../../../src/js/cable_joints/vector2.js';
 import {
     PositionComponent, VelocityComponent, RadiusComponent, MassComponent,
@@ -179,6 +178,10 @@ export function runRemoteGame(world, internalSetupScene, ws) {
         }
 
         world.update(0);
+        const renderSystem = world.getResource('renderSystem');
+        if (renderSystem) {
+            renderSystem.update(world, 0);
+        }
 
         requestAnimationFrame(gameLoop);
     }

--- a/examples/js/slideprinter/runner.js
+++ b/examples/js/slideprinter/runner.js
@@ -1,5 +1,4 @@
 import { dumpWorldState } from '../../../src/js/cable_joints/debugUtils.js';
-import { RenderSystem } from '../flipper/renderSystem.js';
 import { InputSystem } from './slideprinter_common.js';
 
 
@@ -70,7 +69,7 @@ export function runGame(world, internalSetupScene) {
         }
 
 
-        const renderSystem = world.systems.find(s => s instanceof RenderSystem);
+        const renderSystem = world.getResource('renderSystem');
         if (renderSystem) {
             renderSystem.update(world, 0);
         }

--- a/examples/js/slideprinter/setupScene.js
+++ b/examples/js/slideprinter/setupScene.js
@@ -316,6 +316,15 @@ export function setupScene(world, stage, canvas, options = {}) {
           world.registerSystem(new ExtruderSystem());
       }
 
-      world.registerSystem(new RenderSystem(canvas, cScale, simHeight, inputSys.scaleMultiplier, inputSys.viewOffsetX, inputSys.viewOffsetY, 0.2));
+      const renderSystem = new RenderSystem(
+          canvas,
+          cScale,
+          simHeight,
+          inputSys.scaleMultiplier,
+          inputSys.viewOffsetX,
+          inputSys.viewOffsetY,
+          0.2
+      );
+      world.setResource('renderSystem', renderSystem);
     }
 }


### PR DESCRIPTION
## Summary
- avoid registering `RenderSystem` as a normal system in Slideprinter setup
- store the render system as a world resource
- call the stored render system once per frame in both local and remote runners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68664ba4caf08333a689806158ac4e78