### PR TITLE
Full-auto plan: per-pose/per-cable sigma and covariance scaling

### DIFF
--- a/autocal/doc/full_auto_plan_overview.md
+++ b/autocal/doc/full_auto_plan_overview.md
@@ -1,0 +1,24 @@
+# Full-auto calibration implementation plan (overview)
+
+## Goal
+Deliver a `--full-auto` mode that:
+- collects/merges sweeps,
+- runs calibrations with multiple robustness settings (including all `--sweep-metric` options),
+- compares results using a noise-normalized objective,
+- stops when a confidence interval and convergence criteria indicate “good enough”,
+- updates machine config on success, and emits data-quality warnings on failure.
+
+This plan assumes the existing calibration pipeline already computes Fisher information and a covariance estimate for anchors (via the information matrix and pseudo-inverse). It also assumes sweep-wise filtering options are already present (including the three `--sweep-metric` choices).
+
+## High-level flow
+1. **Collect**: For each static pose, record encoder samples per cable and store the mean + robust noise estimate.
+2. **Normalize & optimize**: Use noise-normalized residuals (whitened by per-pose, per-cable `sigma_eff[i][k]`) to drive objective scores and allow cross-dataset comparison via `J(theta) = (1 / N_obs) * sum z^2`.
+3. **Multi-run selection**: Try multiple robustness settings (including all `--sweep-metric` values), rank runs by a common cost + covariance scoring, and select the best run.
+4. **Stop conditions**: Accept when confidence intervals and convergence meet thresholds; otherwise retry or warn.
+5. **Apply configuration**: On success, update config and running machine (per existing desired behavior).
+
+## Documents in this plan
+- **Substep 1:** Add encoder noise measurements to every collected datapoint.
+- **Substep 2:** Define and implement noise-normalized cost & comparable metrics.
+- **Substep 3:** Construct confidence intervals using Fisher information/covariance.
+- **Substep 4:** Orchestrate `--full-auto` runs across sweep-metrics and stop criteria.

--- a/autocal/doc/full_auto_substep_1_encoder_noise.md
+++ b/autocal/doc/full_auto_substep_1_encoder_noise.md
@@ -1,0 +1,43 @@
+# Substep 1: Add encoder noise measurements to every collected datapoint
+
+## Objective
+Capture per-pose encoder noise so residuals can be noise-normalized (whitened). This makes the objective dimensionless and comparable across machines and datasets.
+
+## Required data collection changes
+At each static pose:
+1. **Hold still**: settle for a fixed time.
+2. **Sample encoder**: collect `S` fast encoder readings per cable.
+3. **Store**:
+   - `mu[i][k]`: mean encoder value per cable.
+   - `sigma[i][k]`: robust noise estimate per cable (MAD-based std).
+   - Optional: sampling rate, timestamp, `S`.
+
+## Dataset schema additions
+For each pose entry:
+```json
+{
+  "pose": {"x": ..., "y": ..., "z": ...},
+  "mu": [ ... per cable ... ],
+  "sigma": [ ... per cable ... ],
+  "sample_count": S,
+  "sampling_hz": ...
+}
+```
+
+## Robust sigma policy
+- Use MAD-to-std conversion:
+  - `med = median(x)`
+  - `MAD = median(|x - med|)`
+  - `robust_std(x) = 1.4826 * MAD`
+- Apply a sigma floor to avoid infinite weighting:
+  - `sigma_eff[i][k] = max(sigma[i][k], sigma_min)`
+
+## Acceptance checks (data quality)
+- Flag (but do not delete) poses with:
+  - `sigma` that is non-finite or below the floor.
+  - Too few samples (below a configured minimum).
+
+## Deliverables
+- Updated data collection in the sweep recorder.
+- Dataset migration or compatibility logic to handle pre-noise datasets.
+- Unit tests for sigma estimation and floor logic.

--- a/autocal/doc/full_auto_substep_2_objective_metrics.md
+++ b/autocal/doc/full_auto_substep_2_objective_metrics.md
@@ -1,0 +1,36 @@
+# Substep 2: Define and implement noise-normalized cost & comparable metrics
+
+## Objective
+Implement a dimensionless, comparable cost that works across datasets, machines, and algorithm flags.
+
+## Core definition (whitened residuals)
+For each pose `i` and cable `k`:
+- measurement mean: `mu[i][k]`
+- measured noise: `sigma_eff[i][k]`
+- model prediction: `e_hat[i][k](theta)`
+- residual: `r[i][k] = mu[i][k] - e_hat[i][k](theta)`
+- whitened residual: `z[i][k] = r[i][k] / sigma_eff[i][k]`
+
+### Primary cost (use for optimization and comparison)
+Let `N_obs` be the number of valid `(i,k)` pairs. Use the mean squared whitened residual:
+```
+J(theta) = (1 / N_obs) * sum_{i,k} z[i][k]^2
+```
+If you know parameter count `p`, optionally report a reduced chi-square variant:
+```
+chi2_red(theta) = (1 / (N_obs - p)) * sum_{i,k} z[i][k]^2
+```
+
+## Additional metrics for ranking
+- **Covariance summary**: trace, max std, or determinant of covariance (from Fisher info).
+- **Robust residual summaries**: median |z[i][k]|, 95th percentile, outlier ratio.
+- **Sweep-wise indicators**: per-sweep metric derived from existing sweep filtering.
+
+## Expected integration points
+- Use existing sweep-wise filtering flags and metrics in selection runs (see sweep-metric options).
+- Ensure the same residual definition is used across all algorithm/flag variants to keep comparability.
+
+## Deliverables
+- Functions to compute `J` and optional `J_red` from dataset + model predictions.
+- Standardized metric reporting for full-auto logs.
+- Tests for cost invariance (e.g., constant scaling with sigma).

--- a/autocal/doc/full_auto_substep_3_confidence_interval.md
+++ b/autocal/doc/full_auto_substep_3_confidence_interval.md
@@ -1,0 +1,35 @@
+# Substep 3: Construct confidence intervals using Fisher information
+
+## Objective
+Use the Fisher information matrix to estimate parameter covariance and construct confidence intervals that enable a principled stop condition.
+
+## Existing building blocks
+The active calibration code already computes an information matrix and a covariance estimate (via pseudo-inverse), and reports the matrix rank. These provide the basis for confidence intervals and for diagnosing rank deficiencies.
+
+## Proposed approach
+1. **Compute information matrix** for the current dataset and parameterization.
+2. **Estimate covariance** via pseudo-inverse with optional regularization.
+3. **Scale covariance** by the observed normalized residual variance:
+   - `Cov_scaled = Cov * chi2_red` (or `Cov * J` if you do not compute `chi2_red`).
+   - This is standard in weighted least squares when sigmas are off by a constant factor.
+4. **Extract standard deviations** from the scaled covariance diagonal.
+5. **Build confidence intervals** per parameter:
+   - `CI_95% = estimate ± 1.96 * std` (or 2.0 for simplicity).
+6. **Use CI widths** to enforce the “good enough” threshold, but prefer absolute + relative-to-size thresholds instead of only percent-of-parameter:
+   - `max_anchor_std_mm < X mm`
+   - `max_anchor_std_mm / workspace_diag < Y`
+
+## Handling rank deficiency (5/6 issue)
+If the information matrix is rank-deficient:
+- **Report rank** in logs (already available).
+- **Investigate geometry**: insufficient excitation, symmetric anchor layout, or missing degrees of freedom.
+- **Actionable responses**:
+  - Trigger new sweeps that improve observability.
+  - Increase sweep diversity (e.g., different fixed anchors or deltas).
+  - Apply mild regularization for numerical stability (but track if this masks poor data).
+- **Do not hard-fail by default**: treat rank deficiency as a strong warning and allow success only if observable parameters stabilize and unobservable ones are constrained or held fixed.
+
+## Deliverables
+- Confidence interval computation from covariance matrix.
+- Rank-deficiency detection and user-facing warnings.
+- CI-based stopping criterion using absolute + relative-to-size thresholds.

--- a/autocal/doc/full_auto_substep_4_full_auto_orchestration.md
+++ b/autocal/doc/full_auto_substep_4_full_auto_orchestration.md
@@ -1,0 +1,39 @@
+# Substep 4: Orchestrate full-auto runs across sweep-metrics and stop criteria
+
+## Objective
+Implement a deterministic orchestration layer that tries multiple robustness settings (including all sweep metrics), compares results with the same normalized objective and covariance metrics, then stops when criteria are met.
+
+## Candidate runs
+Run calibration with all `--sweep-metric` options:
+- `mad`
+- `median_abs`
+- `outlier_ratio`
+
+Optionally expand the matrix of runs with:
+- pointwise filtering on/off,
+- sweep-wise filtering on/off,
+- global vs per-sweep MAD.
+
+## Ranking strategy (per dataset)
+1. **Filter invalid runs**:
+   - non-finite cost,
+   - covariance not finite.
+2. **Select the best run** deterministically:
+   - Primary: lowest `J` (or a robust variant like mean rho(z)).
+   - Tie-breaker: smaller scaled covariance summary in **dimensionless** units (e.g., `max_anchor_std_mm / workspace_diag`).
+3. **Select the best run** (lowest primary + tie-breaker), avoiding unit-mixing unless explicitly normalized.
+
+## Stop criteria
+Accept and update config if all conditions are true:
+- Confidence intervals below threshold using absolute + relative-to-size checks (e.g., `max_anchor_std_mm < 10 mm` and `max_anchor_std_mm / workspace_diag < 0.01`).
+- Cost improvement below epsilon for `K` iterations (converged).
+- No data-quality warnings.
+
+Otherwise:
+- If not converged but improving, gather more sweeps.
+- If not converged and data quality poor, emit warning and stop.
+
+## Deliverables
+- Full-auto orchestration CLI or entrypoint.
+- Structured result log summarizing cost, covariance, rank, and run flags.
+- Deterministic run selection + clear warnings.


### PR DESCRIPTION
### Motivation
- Make the full-auto calibration plan numerically robust and unambiguous by addressing per-pose noise, covariance scaling, stopping rules, and run selection stability. 
- Avoid optimistic CIs when unmodeled errors dominate by scaling covariance to observed residual variance. 
- Reduce brittleness from rank-deficiency and unit-mixing in run ranking so `--full-auto` is more reliable across robot sizes and datasets.

### Description
- Clarified that noise normalization uses per-pose, per-cable `sigma_eff[i][k]` in the overview (`autocal/doc/full_auto_plan_overview.md`).
- Added covariance scaling guidance: compute `Cov = pinv(I)` then scale with observed normalized residual variance via `Cov_scaled = Cov * chi2_red` (or `Cov * J`) before extracting stds/CIs (`autocal/doc/full_auto_substep_3_confidence_interval.md`).
- Replaced percent-only CI stop with absolute and relative thresholds and example checks such as `max_anchor_std_mm < 10 mm` and `max_anchor_std_mm / workspace_diag < 0.01` (`autocal/doc/full_auto_substep_3_confidence_interval.md`).
- Treat rank deficiency as a strong warning (do not hard-fail), recommend data-collection strategies to improve observability, and require observable parameters be stable or unobservable ones constrained before success (`autocal/doc/full_auto_substep_3_confidence_interval.md`).
- Simplified orchestration ranking to deterministic rules: primary = lowest `J` (or robust variant) and tie-breaker = dimensionless scaled covariance summary (e.g., `max_anchor_std_mm / workspace_diag`), and removed unit-mixing/automatic hard-fail on rank (`autocal/doc/full_auto_substep_4_full_auto_orchestration.md`).

### Testing
- No automated tests were run because these are documentation-only changes; no code behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5f742a1c833389097e3cbdb5c4bd)